### PR TITLE
Code quality fix - "entrySet()" should be iterated when both the key and value are needed.

### DIFF
--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/TaintUtils.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/TaintUtils.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import sun.misc.VM;
 
@@ -184,9 +185,9 @@ public class TaintUtils {
 	private static String processReverse(String type) {
 		type = type.trim();
 		if(type.length() == 1)  {
-			for(String s : typeToSymbol.keySet()) 
-				if(typeToSymbol.get(s).equals(type))
-					return s;
+			for(Entry<String, String> s : typeToSymbol.entrySet()) 
+				if(s.getValue().equals(type))
+					return s.getKey();
 			throw new IllegalArgumentException("Invalid type string");
 		}
 			

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/LocalVariableManager.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/LocalVariableManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map.Entry;
 
 import edu.columbia.cs.psl.phosphor.Configuration;
 import edu.columbia.cs.psl.phosphor.TaintUtils;
@@ -441,15 +442,15 @@ public class LocalVariableManager extends OurLocalVariablesSorter implements Opc
         // 'newLocals' currently empty
 
         if(!disabled)
-        for(Type t : preAllocedReturnTypes.keySet())
+        for(Entry<Type, Integer> t : preAllocedReturnTypes.entrySet())
         {
 //        	System.out.println(t);
-        	if(t.getSort() != Type.OBJECT)
+        	if(t.getKey().getSort() != Type.OBJECT)
         		continue;
-        	int idx = preAllocedReturnTypes.get(t);
+        	int idx = t.getValue();
         	if(idx >= 0)
         	{
-        		setFrameLocal(idx, t.getInternalName());
+        		setFrameLocal(idx, t.getKey());
         	}
         }
 //        System.out.println(Arrays.toString(newLocals));

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/PopOptimizingMV.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/PopOptimizingMV.java
@@ -2,6 +2,7 @@ package edu.columbia.cs.psl.phosphor.instrumenter;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map.Entry;
 
 import org.objectweb.asm.Type;
 
@@ -590,11 +591,11 @@ public class PopOptimizingMV extends MethodVisitor implements Opcodes {
 			if (TaintUtils.DEBUG_OPT)
 				System.out.println(owner + "." + name + "NPOP: " + nPop);
 			HashSet<Integer> lvsToObliterate = new HashSet<Integer>();
-			for (Integer i : lvIsWrittenNotRead.keySet())
-				if (lvIsWrittenNotRead.get(i)) {
+			for (Entry<Integer, Boolean> i : lvIsWrittenNotRead.entrySet())
+				if (i.getValue()) {
 					if (TaintUtils.DEBUG_OPT)
-						System.out.println("BLow away: " + i);
-					lvsToObliterate.add(i);
+						System.out.println("BLow away: " + i.getKey());
+					lvsToObliterate.add(i.getKey());
 				}
 			if (!lvsToObliterate.isEmpty()) {
 				insn = this.instructions.getFirst();

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/PrimitiveArrayAnalyzer.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/PrimitiveArrayAnalyzer.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Stack;
 
 import edu.columbia.cs.psl.phosphor.Configuration;
@@ -300,16 +301,17 @@ public class PrimitiveArrayAnalyzer extends MethodVisitor {
 //							System.out.println("OUT: " + i + " " + (outFrames.get(i) == null ? "null" : outFrames.get(i).stack));
 //						}
 
-					for (Integer successor : edges.keySet()) {
-						if (edges.get(successor).size() > 1) {
+					for (Entry<Integer, LinkedList<Integer>> edge : edges.entrySet()) {
+					    Integer successor = edge.getKey();
+						if (edge.getValue().size() > 1) {
 							int labelToSuccessor = getLabel(successor);
 
 							if (DEBUG)
-								System.out.println(name + " Must merge: " + edges.get(successor) + " into " + successor + " AKA " + labelToSuccessor);
+								System.out.println(name + " Must merge: " + edge.getValue() + " into " + successor + " AKA " + labelToSuccessor);
 							if (DEBUG)
 								System.out.println("Input to successor: " + inFrames.get(labelToSuccessor).stack);
 
-							for (Integer toMerge : edges.get(successor)) {
+							for (Integer toMerge : edge.getValue()) {
 								int labelToMerge = getLabel(toMerge);
 								if (DEBUG)
 									System.out.println(toMerge + " AKA " + labelToMerge);

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/TaintTrackingClassVisitor.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/TaintTrackingClassVisitor.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Scanner;
+import java.util.Map.Entry;
 
 import edu.columbia.cs.psl.phosphor.Configuration;
 import edu.columbia.cs.psl.phosphor.Instrumenter;
@@ -1092,7 +1093,8 @@ public class TaintTrackingClassVisitor extends ClassVisitor {
 		{
 			//make a copy of each raw method, using the proper suffix. right now this only goes 
 			//one level deep - and it will call back into instrumented versions
-			for (MethodNode mn : forMore.keySet()) {
+			for (Entry<MethodNode, MethodNode> am : forMore.entrySet()) {
+			    MethodNode mn = am.getKey();
 				if(mn.name.equals("<clinit>"))
 					continue;
 				String mName = mn.name;
@@ -1106,7 +1108,7 @@ public class TaintTrackingClassVisitor extends ClassVisitor {
 					mName += TaintUtils.METHOD_SUFFIX_UNINST;
 				}
 				MethodVisitor mv = super.visitMethod(mn.access & ~Opcodes.ACC_NATIVE, mName, mDesc, mn.signature, (String[]) mn.exceptions.toArray(new String[0]));
-				MethodNode meth = forMore.get(mn);
+				MethodNode meth = am.getValue();
 
 				if ((mn.access & Opcodes.ACC_NATIVE) != 0) {
 					GeneratorAdapter ga = new GeneratorAdapter(mv, mn.access, mn.name, mn.desc);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864

Please let me know if you have any questions.

Faisal Hameed