### PR TITLE
Code quality fix - Method invokes inefficient Number constructor; use static valueOf instead.

### DIFF
--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/BoxedPrimitiveStoreWithIntTags.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/BoxedPrimitiveStoreWithIntTags.java
@@ -53,7 +53,7 @@ public class BoxedPrimitiveStoreWithIntTags {
 
 	public static Byte valueOf(int tag, byte z) {
 		if (tag > 0) {
-			Byte r = new Byte(z);
+			Byte r = Byte.valueOf(z);
 			tags.put(r, tag);
 			return r;
 		}
@@ -62,7 +62,7 @@ public class BoxedPrimitiveStoreWithIntTags {
 
 	public static Character valueOf(int tag, char z) {
 		if (tag > 0) {
-			Character r = new Character(z);
+			Character r = Character.valueOf(z);
 			tags.put(r, tag);
 			return r;
 		}
@@ -71,7 +71,7 @@ public class BoxedPrimitiveStoreWithIntTags {
 
 	public static Short valueOf(int tag, short z) {
 		if (tag > 0) {
-			Short r = new Short(z);
+			Short r = Short.valueOf(z);
 			tags.put(r, tag);
 			return r;
 		}

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/BoxedPrimitiveStoreWithObjTags.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/BoxedPrimitiveStoreWithObjTags.java
@@ -53,7 +53,7 @@ public class BoxedPrimitiveStoreWithObjTags {
 
 	public static Byte valueOf(Object tag, byte z) {
 		if (tag != null) {
-			Byte r = new Byte(z);
+			Byte r = Byte.valueOf(z);
 			tags.put(r, tag);
 			return r;
 		}
@@ -62,7 +62,7 @@ public class BoxedPrimitiveStoreWithObjTags {
 
 	public static Character valueOf(Object tag, char z) {
 		if (tag != null) {
-			Character r = new Character(z);
+			Character r = Character.valueOf(z);
 			tags.put(r, tag);
 			return r;
 		}
@@ -71,7 +71,7 @@ public class BoxedPrimitiveStoreWithObjTags {
 
 	public static Short valueOf(Object tag, short z) {
 		if (tag != null) {
-			Short r = new Short(z);
+			Short r = Short.valueOf(z);
 			tags.put(r, tag);
 			return r;
 		}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
findbugs:DM_NUMBER_CTOR - Performance - Method invokes inefficient Number constructor; use static valueOf instead.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/findbugs:DM_NUMBER_CTOR

Please let me know if you have any questions.

Faisal Hameed