### PR TITLE
Code quality fix - Literal boolean values should not be used in condition expressions.

### DIFF
--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/Configuration.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/Configuration.java
@@ -50,7 +50,7 @@ public class Configuration {
 	public static int TAINT_ARRAY_STORE_OPCODE = (!MULTI_TAINTING ? Opcodes.IASTORE : Opcodes.AASTORE);
 	public static int TAINT_LOAD_OPCODE = (!MULTI_TAINTING ? Opcodes.ILOAD : Opcodes.ALOAD);
 	public static int TAINT_STORE_OPCODE = (!MULTI_TAINTING ? Opcodes.ISTORE : Opcodes.ASTORE);
-	public static boolean OPT_CONSTANT_ARITHMETIC = true && !IMPLICIT_TRACKING;
+	public static boolean OPT_CONSTANT_ARITHMETIC = !IMPLICIT_TRACKING;
 	public static Class TAINT_TAG_OBJ_CLASS = (Taint.class);
 	public static Class TAINT_TAG_OBJ_ARRAY_CLASS = (Taint[].class);
 
@@ -76,7 +76,7 @@ public class Configuration {
 		TAINT_ARRAY_STORE_OPCODE = (!MULTI_TAINTING ? Opcodes.IASTORE : Opcodes.AASTORE);
 		TAINT_LOAD_OPCODE = (!MULTI_TAINTING ? Opcodes.ILOAD : Opcodes.ALOAD);
 		TAINT_STORE_OPCODE = (!MULTI_TAINTING ? Opcodes.ISTORE : Opcodes.ASTORE);
-		OPT_CONSTANT_ARITHMETIC = true && !IMPLICIT_TRACKING;
+		OPT_CONSTANT_ARITHMETIC = !IMPLICIT_TRACKING;
 		TAINT_TAG_OBJ_ARRAY_CLASS = (MULTI_TAINTING ? Taint[].class : int[].class);
 		TAINT_TAG_OBJ_CLASS = (MULTI_TAINTING ? Taint.class : Integer.TYPE);
 		

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/TaintUtils.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/TaintUtils.java
@@ -100,16 +100,16 @@ public class TaintUtils {
 
 	public static final String METHOD_SUFFIX = "$$PHOSPHORTAGGED";
 	public static final boolean DEBUG_ALL = false;
-	public static final boolean DEBUG_DUPSWAP = false || DEBUG_ALL;
-	public static final boolean DEBUG_FRAMES = false || DEBUG_ALL;
-	public static final boolean DEBUG_FIELDS = false || DEBUG_ALL;
-	public static final boolean DEBUG_LOCAL = false || DEBUG_ALL;
-	public static final boolean DEBUG_CALLS = false || DEBUG_ALL;
+	public static final boolean DEBUG_DUPSWAP = DEBUG_ALL;
+	public static final boolean DEBUG_FRAMES = DEBUG_ALL;
+	public static final boolean DEBUG_FIELDS = DEBUG_ALL;
+	public static final boolean DEBUG_LOCAL = DEBUG_ALL;
+	public static final boolean DEBUG_CALLS = DEBUG_ALL;
 	public static final boolean DEBUG_OPT = false;
 	public static final boolean DEBUG_PURE = false;
 
 	public static final boolean ADD_BASIC_ARRAY_CONSTRAINTS = true;
-	public static final boolean ADD_HEAVYWEIGHT_ARRAY_TAINTS = ADD_BASIC_ARRAY_CONSTRAINTS || true;
+	public static final boolean ADD_HEAVYWEIGHT_ARRAY_TAINTS = ADD_BASIC_ARRAY_CONSTRAINTS;
 
 	public static int nextTaint = 0;
 	public static int nextTaintPHOSPHOR_TAG = 0;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1125 - Literal boolean values should not be used in condition expressions. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1125

Please let me know if you have any questions.

Faisal Hameed