### PR TITLE
Code quality fix - Boxing and unboxing should not be immediately reversed.

### DIFF
--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/BoxedPrimitiveStoreWithIntTags.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/BoxedPrimitiveStoreWithIntTags.java
@@ -12,7 +12,7 @@ public class BoxedPrimitiveStoreWithIntTags {
 
 	public static TaintedBooleanWithIntTag booleanValue(Boolean z) {
 		TaintedBooleanWithIntTag ret = new TaintedBooleanWithIntTag();
-		ret.val = z.booleanValue();
+		ret.val = z;
 		if (tags.containsKey(z))
 			ret.taint = tags.get(z);
 		return ret;
@@ -20,7 +20,7 @@ public class BoxedPrimitiveStoreWithIntTags {
 
 	public static TaintedByteWithIntTag byteValue(Byte z) {
 		TaintedByteWithIntTag ret = new TaintedByteWithIntTag();
-		ret.val = z.byteValue();
+		ret.val = z;
 		if (tags.containsKey(z))
 			ret.taint = tags.get(z);
 		return ret;
@@ -28,7 +28,7 @@ public class BoxedPrimitiveStoreWithIntTags {
 
 	public static TaintedShortWithIntTag shortValue(Short z) {
 		TaintedShortWithIntTag ret = new TaintedShortWithIntTag();
-		ret.val = z.shortValue();
+		ret.val = z;
 		if (tags.containsKey(z))
 			ret.taint = tags.get(z);
 		return ret;

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/BoxedPrimitiveStoreWithObjTags.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/BoxedPrimitiveStoreWithObjTags.java
@@ -12,7 +12,7 @@ public class BoxedPrimitiveStoreWithObjTags {
 
 	public static TaintedBooleanWithObjTag booleanValue(Boolean z) {
 		TaintedBooleanWithObjTag ret = new TaintedBooleanWithObjTag();
-		ret.val = z.booleanValue();
+		ret.val = z;
 		if (tags.containsKey(z))
 			ret.taint = tags.get(z);
 		return ret;
@@ -20,7 +20,7 @@ public class BoxedPrimitiveStoreWithObjTags {
 
 	public static TaintedByteWithObjTag byteValue(Byte z) {
 		TaintedByteWithObjTag ret = new TaintedByteWithObjTag();
-		ret.val = z.byteValue();
+		ret.val = z;
 		if (tags.containsKey(z))
 			ret.taint = tags.get(z);
 		return ret;
@@ -28,7 +28,7 @@ public class BoxedPrimitiveStoreWithObjTags {
 
 	public static TaintedShortWithObjTag shortValue(Short z) {
 		TaintedShortWithObjTag ret = new TaintedShortWithObjTag();
-		ret.val = z.shortValue();
+		ret.val = z;
 		if (tags.containsKey(z))
 			ret.taint = tags.get(z);
 		return ret;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2153 - Boxing and unboxing should not be immediately reversed.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2153

Please let me know if you have any questions.

Faisal Hameed