### PR TITLE
Code quality fix - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.

### DIFF
--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/Instrumenter.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/Instrumenter.java
@@ -380,7 +380,7 @@ public class Instrumenter {
 		_main(line.getArgs());
 		if (Configuration.WITH_SELECTIVE_INST) {
 			// write out file again
-			StringBuffer buf = new StringBuffer();
+			StringBuilder buf = new StringBuilder();
 			for (MethodDescriptor desc : SelectiveInstrumentationManager.methodsToInstrument)
 				buf.append(TaintUtils.getMethodDesc(desc)).append("\n");
 			TaintUtils.writeToFile(new File(rootOutputDir.getAbsolutePath() + "/methods"), buf.toString());

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/TaintUtils.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/TaintUtils.java
@@ -167,7 +167,7 @@ public class TaintUtils {
 		return "L"+in.replace('.', '/')+";";
 	}
 	private static String processType(String type) {
-		StringBuffer typeBuffer = new StringBuffer();
+	    StringBuilder typeBuffer = new StringBuilder();
 		type = type.trim();
 		int firstBracket = type.indexOf('[');
 		if(firstBracket >= 0) {
@@ -225,7 +225,7 @@ public class TaintUtils {
 		 
 		// get args list
 		temp = temp.substring(nameEnd+1,temp.length()-2);
-		StringBuffer argsBuffer = new StringBuffer();
+		StringBuilder argsBuffer = new StringBuilder();
 	
 		argsBuffer.append("(");
 		if(temp != null && !temp.isEmpty()) {
@@ -268,7 +268,7 @@ public class TaintUtils {
 			}
 			args = args.substring(idx);
 		}
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append("<").append(owner).append(": ").append(actualReturnType).append(" ").append(methodName).append("(");
 		for(String s : arguments)
 			buf.append(s).append(",");

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/DoubleLinkedList.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/DoubleLinkedList.java
@@ -60,7 +60,7 @@ public class DoubleLinkedList<T> implements Cloneable {
 	}
 	@Override
 	public String toString() {
-		StringBuffer ret = new StringBuffer();
+	    StringBuilder ret = new StringBuilder();
 		ret.append("[");
 		Node<T> e = getFirst();
 		while(e != null)

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/LinkedList.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/LinkedList.java
@@ -75,7 +75,7 @@ public class LinkedList<T> implements Cloneable {
 	}
 	@Override
 	public String toString() {
-		StringBuffer ret = new StringBuffer();
+	    StringBuilder ret = new StringBuilder();
 		ret.append("[");
 		Node<T> e = getFirst();
 		while(e != null)


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149

Please let me know if you have any questions.

Faisal Hameed