### PR TITLE
remove option MaxPermSize=512m

### DIFF
--- a/Phosphor/instrumentJRE.sh
+++ b/Phosphor/instrumentJRE.sh
@@ -5,7 +5,7 @@ else
 	echo "Ensuring instrumented JREs exist for tests... to refresh, do mvn clean\n";
 	if [ ! -d "target/jre-inst-int" ]; then
 		echo "Creating int tag instrumented JRE\n";
-		java -Xmx6g -XX:MaxPermSize=512m -jar target/Phosphor-0.0.2-SNAPSHOT.jar -forceUnboxAcmpEq -withEnumsByValue $JAVA_HOME target/jre-inst-int;
+		java -Xmx6g -jar target/Phosphor-0.0.2-SNAPSHOT.jar -forceUnboxAcmpEq -withEnumsByValue $JAVA_HOME target/jre-inst-int;
 		chmod +x target/jre-inst-int/bin/*;
 		chmod +x target/jre-inst-int/lib/*;
 		chmod +x target/jre-inst-int/jre/bin/*;
@@ -15,7 +15,7 @@ else
 	fi
 	if [ ! -d "target/jre-inst-int-untaggedwrappers" ]; then
 		echo "Creating int tag instrumented JRE with untagged wrappers\n";
-		java -Xmx6g -XX:MaxPermSize=512m -jar target/Phosphor-0.0.2-SNAPSHOT.jar -forceUnboxAcmpEq -withEnumsByValue -generateUninstStubs $JAVA_HOME target/jre-inst-int-untaggedwrappers;
+		java -Xmx6g -jar target/Phosphor-0.0.2-SNAPSHOT.jar -forceUnboxAcmpEq -withEnumsByValue -generateUninstStubs $JAVA_HOME target/jre-inst-int-untaggedwrappers;
 		chmod +x target/jre-inst-int-untaggedwrappers/bin/*;
 		chmod +x target/jre-inst-int-untaggedwrappers/lib/*;
 		chmod +x target/jre-inst-int-untaggedwrappers/jre/bin/*;
@@ -26,7 +26,7 @@ else
 
 	if [ ! -d "target/jre-inst-obj" ]; then
 			echo "Creating obj tag instrumented JRE\n";
-		java -Xmx6g -XX:MaxPermSize=512m  -jar target/Phosphor-0.0.2-SNAPSHOT.jar -multiTaint -forceUnboxAcmpEq -withEnumsByValue $JAVA_HOME target/jre-inst-obj;
+		java -Xmx6g -jar target/Phosphor-0.0.2-SNAPSHOT.jar -multiTaint -forceUnboxAcmpEq -withEnumsByValue $JAVA_HOME target/jre-inst-obj;
 		chmod +x target/jre-inst-obj/bin/*;
 		chmod +x target/jre-inst-obj/lib/*;
 		chmod +x target/jre-inst-obj/jre/bin/*;
@@ -36,7 +36,7 @@ else
 	fi
 	if [ ! -d "target/jre-inst-implicit" ]; then
 		echo "Creating obj tag + implicit flow instrumented JRE\n";
-		java -Xmx6g -XX:MaxPermSize=512m -jar target/Phosphor-0.0.2-SNAPSHOT.jar -controlTrack -multiTaint -forceUnboxAcmpEq -withEnumsByValue $JAVA_HOME target/jre-inst-implicit;
+		java -Xmx6g -jar target/Phosphor-0.0.2-SNAPSHOT.jar -controlTrack -multiTaint -forceUnboxAcmpEq -withEnumsByValue $JAVA_HOME target/jre-inst-implicit;
 		chmod +x target/jre-inst-implicit/bin/*;
 		chmod +x target/jre-inst-implicit/lib/*;
 		chmod +x target/jre-inst-implicit/jre/bin/*;


### PR DESCRIPTION
When I run `mvn verify`, there is a warning:
`OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=512m; support was removed in 8.0`
Remove this option in the shell script.