### PR TITLE
Fix for taint sinks

### DIFF
--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/BasicSourceSinkManager.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/BasicSourceSinkManager.java
@@ -110,6 +110,11 @@ public class BasicSourceSinkManager extends SourceSinkManager {
 		if (c1.equals(c2))
 			return true;
 		ClassNode cn = Instrumenter.classes.get(c2);
+
+		if (cn == null) {
+			return false;
+		}
+
 		if (cn.interfaces != null)
 			for (Object s : cn.interfaces) {
 				if (c1IsSuperforC2(c1, (String) s))


### PR DESCRIPTION
If a test application code does not contain the sink methods in a taint-sink file which is used by phosphor to instrument the applications code, a lot of exceptions would be thrown. This fix is for that.