### PR TITLE
Lazy arrays

### DIFF
--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/LazyArrayObjTags.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/LazyArrayObjTags.java
@@ -12,6 +12,8 @@ import edu.columbia.cs.psl.phosphor.struct.TaintedShortWithObjTag;
 public class LazyArrayObjTags implements Cloneable {
 //	public static final String INTERNAL_NAME = "edu/columbia/cs/psl/phosphor/runtime/LazyArrayIntTags";
 	public Taint[] taints;
+	
+	public Taint arTaint;
 
 	public LazyArrayObjTags(Taint[] taints) {
 		this.taints = taints;

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/LazyArrayObjTags.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/LazyArrayObjTags.java
@@ -25,8 +25,10 @@ public class LazyArrayObjTags implements Cloneable {
 	@Override
 	public Object clone() {
 		LazyArrayObjTags ret = new LazyArrayObjTags();
-		if(taints != null)
+		if(taints != null) {
+			ret.arTaint = arTaint.copy();
 			ret.taints = taints.clone();
+		}
 		return ret;
 	}
 

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/MultiTainter.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/MultiTainter.java
@@ -66,26 +66,50 @@ public final class MultiTainter {
 	{
 		throw new IllegalStateException("Calling uninstrumented Phosphor stubs!");
 	}
+	public static int[] taintedBooleanArray(boolean[] in, Object arrLbl, Object eleLbl)
+    {
+        throw new IllegalStateException("Calling uninstrumented Phosphor stubs!");
+    }
 	public static byte[] taintedByteArray(byte[] in, Object lbl)
 	{
 		throw new IllegalStateException("Calling uninstrumented Phosphor stubs!");
 	}
+	public static int[] taintedByteArray(byte[] in, Object arrLbl, Object eleLbl)
+    {
+        throw new IllegalStateException("Calling uninstrumented Phosphor stubs!");
+    }
 	public static char[] taintedCharArray(char[] in, Object lbl)
 	{
 		throw new IllegalStateException("Calling uninstrumented Phosphor stubs!");
 	}
+	public static int[] taintedCharArray(char[] in, Object arrLbl, Object eleLbl)
+    {
+        throw new IllegalStateException("Calling uninstrumented Phosphor stubs!");
+    }
 	public static double[] taintedDoubleArray(double[] in, Object lbl)
 	{
 		throw new IllegalStateException("Calling uninstrumented Phosphor stubs!");
 	}
+	public static int[] taintedDoubleArray(double[] in, Object arrLbl, Object eleLbl)
+    {
+        throw new IllegalStateException("Calling uninstrumented Phosphor stubs!");
+    }
 	public static float[] taintedFloatArray(float[] in, Object lbl)
 	{
 		throw new IllegalStateException("Calling uninstrumented Phosphor stubs!");
 	}
+	public static int[] taintedFloatArray(float[] in, Object arrLbl, Object eleLbl)
+    {
+        throw new IllegalStateException("Calling uninstrumented Phosphor stubs!");
+    }
 	public static long[] taintedLongArray(long[] in, Object lbl)
 	{
 		throw new IllegalStateException("Calling uninstrumented Phosphor stubs!");
 	}
+	public static int[] taintedLongArray(long[] in, Object arrLbl, Object eleLbl)
+    {
+        throw new IllegalStateException("Calling uninstrumented Phosphor stubs!");
+    }
 	public static int[] taintedIntArray(int[] in, Object lbl)
 	{
 		throw new IllegalStateException("Calling uninstrumented Phosphor stubs!");
@@ -98,6 +122,10 @@ public final class MultiTainter {
 	{
 		throw new IllegalStateException("Calling uninstrumented Phosphor stubs!");
 	}
+	public static int[] taintedShortArray(short[] in, Object arrLbl, Object eleLbl)
+    {
+        throw new IllegalStateException("Calling uninstrumented Phosphor stubs!");
+    }
 	public static Taint getTaint(boolean in)
 	{
 		throw new IllegalStateException("Calling uninstrumented Phosphor stubs!");
@@ -220,6 +248,16 @@ public final class MultiTainter {
 		ret.val = in;
 		return ret;
 	}
+	public static TaintedBooleanArrayWithObjTag taintedBooleanArray$$PHOSPHORTAGGED(LazyArrayObjTags oldTag, boolean[] in, Object arrLbl, Object eleLbl, TaintedBooleanArrayWithObjTag ret)
+    {
+            ret.taint = new LazyArrayObjTags(new Taint[in.length]);
+            Taint arTaint = new Taint(arrLbl);
+            ret.taint.arTaint = arTaint;
+            for(int i =0 ; i < in.length; i++)
+            	ret.taint.taints[i] = new Taint(eleLbl);
+            ret.val = in;
+            return ret;
+    }
 	public static TaintedByteArrayWithObjTag taintedByteArray$$PHOSPHORTAGGED(LazyArrayObjTags oldTag, byte[] in, Object lbl, TaintedByteArrayWithObjTag ret)
 	{
 		ret.taint = new LazyArrayObjTags(new Taint[in.length]);
@@ -228,6 +266,16 @@ public final class MultiTainter {
 		ret.val = in;
 		return ret;
 	}
+	public static TaintedByteArrayWithObjTag taintedByteArray$$PHOSPHORTAGGED(LazyArrayObjTags oldTag, byte[] in, Object arrLbl, Object eleLbl, TaintedByteArrayWithObjTag ret)
+    {
+            ret.taint = new LazyArrayObjTags(new Taint[in.length]);
+            Taint arTaint = new Taint(arrLbl);
+            ret.taint.arTaint = arTaint;
+            for(int i =0 ; i < in.length; i++)
+            	ret.taint.taints[i] = new Taint(eleLbl);
+            ret.val = in;
+            return ret;
+    }
 	public static TaintedCharArrayWithObjTag taintedCharArray$$PHOSPHORTAGGED(LazyArrayObjTags oldTag, char[] in, Object lbl, TaintedCharArrayWithObjTag ret)
 	{
 		ret.taint = new LazyArrayObjTags(new Taint[in.length]);
@@ -236,6 +284,16 @@ public final class MultiTainter {
 		ret.val = in;
 		return ret;
 	}
+	public static TaintedCharArrayWithObjTag taintedCharArray$$PHOSPHORTAGGED(LazyArrayObjTags oldTag, char[] in, Object arrLbl, Object eleLbl, TaintedCharArrayWithObjTag ret)
+    {
+            ret.taint = new LazyArrayObjTags(new Taint[in.length]);
+            Taint arTaint = new Taint(arrLbl);
+            ret.taint.arTaint = arTaint;
+            for(int i =0 ; i < in.length; i++)
+            	ret.taint.taints[i] = new Taint(eleLbl);
+            ret.val = in;
+            return ret;
+    }
 	public static TaintedDoubleArrayWithObjTag taintedDoubleArray$$PHOSPHORTAGGED(LazyArrayObjTags oldTag, double[] in, Object lbl, TaintedDoubleArrayWithObjTag ret)
 	{
 		ret.taint = new LazyArrayObjTags(new Taint[in.length]);
@@ -244,6 +302,16 @@ public final class MultiTainter {
 		ret.val = in;
 		return ret;
 	}
+	public static TaintedDoubleArrayWithObjTag taintedDoubleArray$$PHOSPHORTAGGED(LazyArrayObjTags oldTag, double[] in, Object arrLbl, Object eleLbl, TaintedDoubleArrayWithObjTag ret)
+    {
+            ret.taint = new LazyArrayObjTags(new Taint[in.length]);
+            Taint arTaint = new Taint(arrLbl);
+            ret.taint.arTaint = arTaint;
+            for(int i =0 ; i < in.length; i++)
+            	ret.taint.taints[i] = new Taint(eleLbl);
+            ret.val = in;
+            return ret;
+    }
 	public static TaintedFloatArrayWithObjTag taintedFloatArray$$PHOSPHORTAGGED(LazyArrayObjTags oldTag, float[] in, Object lbl, TaintedFloatArrayWithObjTag ret)
 	{
 		ret.taint = new LazyArrayObjTags(new Taint[in.length]);
@@ -252,6 +320,16 @@ public final class MultiTainter {
 		ret.val = in;
 		return ret;
 	}
+	public static TaintedFloatArrayWithObjTag taintedFloatArray$$PHOSPHORTAGGED(LazyArrayObjTags oldTag, float[] in, Object arrLbl, Object eleLbl, TaintedFloatArrayWithObjTag ret)
+    {
+            ret.taint = new LazyArrayObjTags(new Taint[in.length]);
+            Taint arTaint = new Taint(arrLbl);
+            ret.taint.arTaint = arTaint;
+            for(int i =0 ; i < in.length; i++)
+            	ret.taint.taints[i] = new Taint(eleLbl);
+            ret.val = in;
+            return ret;
+    }
 	public static TaintedIntArrayWithObjTag taintedIntArray$$PHOSPHORTAGGED(LazyArrayObjTags oldTag, int[] in, Object lbl, TaintedIntArrayWithObjTag ret)
 	{
 		ret.taint = new LazyArrayObjTags(new Taint[in.length]);
@@ -278,6 +356,16 @@ public final class MultiTainter {
 		ret.val = in;
 		return ret;
 	}
+	public static TaintedShortArrayWithObjTag taintedShortArray$$PHOSPHORTAGGED(LazyArrayObjTags oldTag, short[] in, Object arrLbl, Object eleLbl, TaintedShortArrayWithObjTag ret)
+    {
+            ret.taint = new LazyArrayObjTags(new Taint[in.length]);
+            Taint arTaint = new Taint(arrLbl);
+            ret.taint.arTaint = arTaint;
+            for(int i =0 ; i < in.length; i++)
+            	ret.taint.taints[i] = new Taint(eleLbl);
+            ret.val = in;
+            return ret;
+    }
 	public static TaintedLongArrayWithObjTag taintedLongArray$$PHOSPHORTAGGED(LazyArrayObjTags oldTag, long[] in, Object lbl, TaintedLongArrayWithObjTag ret)
 	{
 		ret.taint = new LazyArrayObjTags(new Taint[in.length]);
@@ -286,6 +374,16 @@ public final class MultiTainter {
 		ret.val = in;
 		return ret;
 	}
+	public static TaintedLongArrayWithObjTag taintedLongArray$$PHOSPHORTAGGED(LazyArrayObjTags oldTag, long[] in, Object arrLbl, Object eleLbl, TaintedLongArrayWithObjTag ret)
+    {
+            ret.taint = new LazyArrayObjTags(new Taint[in.length]);
+            Taint arTaint = new Taint(arrLbl);
+            ret.taint.arTaint = arTaint;
+            for(int i =0 ; i < in.length; i++)
+            	ret.taint.taints[i] = new Taint(eleLbl);
+            ret.val = in;
+            return ret;
+    }
 	public static Taint getTaint$$PHOSPHORTAGGED(Object obj)
 	{
 		return getTaint(obj);

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/MultiTainter.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/MultiTainter.java
@@ -90,6 +90,10 @@ public final class MultiTainter {
 	{
 		throw new IllegalStateException("Calling uninstrumented Phosphor stubs!");
 	}
+	public static int[] taintedIntArray(int[] in, Object arrLbl, Object eleLbl)
+    {
+        throw new IllegalStateException("Calling uninstrumented Phosphor stubs!");
+    }
 	public static short[] taintedShortArray(short[] in, Object lbl)
 	{
 		throw new IllegalStateException("Calling uninstrumented Phosphor stubs!");
@@ -256,6 +260,16 @@ public final class MultiTainter {
 		ret.val = in;
 		return ret;
 	}
+	public static TaintedIntArrayWithObjTag taintedIntArray$$PHOSPHORTAGGED(LazyArrayObjTags oldTag, int[] in, Object arrLbl, Object eleLbl, TaintedIntArrayWithObjTag ret)
+    {
+            ret.taint = new LazyArrayObjTags(new Taint[in.length]);
+            Taint arTaint = new Taint(arrLbl);
+            ret.taint.arTaint = arTaint;
+            for(int i =0 ; i < in.length; i++)
+            	ret.taint.taints[i] = new Taint(eleLbl);
+            ret.val = in;
+            return ret;
+    }
 	public static TaintedShortArrayWithObjTag taintedShortArray$$PHOSPHORTAGGED(LazyArrayObjTags oldTag, short[] in, Object lbl, TaintedShortArrayWithObjTag ret)
 	{
 		ret.taint = new LazyArrayObjTags(new Taint[in.length]);
@@ -279,8 +293,10 @@ public final class MultiTainter {
 
 	public static final Taint getTaint(Object obj)
 	{
-		if(obj instanceof MultiDTaintedArrayWithObjTag)
-			obj = ((MultiDTaintedArrayWithObjTag) obj).getVal();
+		if(obj instanceof MultiDTaintedArrayWithObjTag) {
+			Taint ret = ((MultiDTaintedArrayWithObjTag) obj).taint.arTaint;
+			return ret;
+		}
 		if(Configuration.taintTagFactory == null)
 			return null;
 		if(obj instanceof TaintedWithObjTag)

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/IOTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/IOTagITCase.java
@@ -15,19 +15,29 @@ public class IOTagITCase {
 		int[] arr = {1, 2, 3};
 		ArrayList<String> lbls = new ArrayList<String>();
 		lbls.add("arrTaint");
-		arr = MultiTainter.taintedIntArray(arr, lbls);
+		arr = MultiTainter.taintedIntArray(arr, lbls, lbls);
+		//System.out.println("arr taint: " + MultiTainter.getTaint(arr));
 		//System.out.println("arr[0] taint: " + MultiTainter.getTaint(arr[0]));
-		assertEquals(lbls, MultiTainter.getTaint(arr[0]));
+		assertEquals("[arrTaint]", MultiTainter.getTaint(arr).getLabel().toString());
+		assertEquals("[arrTaint]", MultiTainter.getTaint(arr[0]).getLabel().toString());
 		
 		ArrayList<String> intTaints = new ArrayList<String>();
 		intTaints.add("intTaint");
 		int i = MultiTainter.taintedInt(5, intTaints);
-		//System.out.println("i taint: " + MultiTainter.getTaint(i));
-		assertEquals(intTaints, MultiTainter.getTaint(i));
+		
+		ArrayList<String> intTaints2 = new ArrayList<String>();
+		intTaints2.add("intTaint2");
+		int j = MultiTainter.taintedInt(7, intTaints2);
 		
 		arr[0] = i + 9;
-		//System.out.println("arr[0] taint again: " + MultiTainter.getTaint(arr[0]).getDependencies().toString());
-		assertEquals("[intTaint]", MultiTainter.getTaint(arr[0]).getDependencies().toString());
+		//System.out.println("arr[0] taint by i: " + MultiTainter.getTaint(arr[0]));
+		assertEquals("[intTaint]", MultiTainter.getTaint(arr[0]).getLabel().toString());
+		assertEquals("[]", MultiTainter.getTaint(arr[0]).getDependencies().toString());
+		
+		arr[0] = i + j;
+		//System.out.println("arr[0] taint again: " + MultiTainter.getTaint(arr[0]));
+		assertNull(MultiTainter.getTaint(arr[0]).getLabel());
+		assertEquals("[[intTaint] [intTaint2] ]", MultiTainter.getTaint(arr[0]).getDependencies().toString());
 	}
 	
 	public static void main(String[] args) {

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/IOTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/IOTagITCase.java
@@ -1,0 +1,33 @@
+package edu.columbia.cs.psl.test.phosphor;
+
+import java.util.ArrayList;
+import static org.junit.Assert.*;
+
+import edu.columbia.cs.psl.phosphor.runtime.MultiTainter;
+
+public class IOTagITCase {
+	
+	public static void testIncrementArray() {
+		int[] arr = {1, 2, 3};
+		ArrayList<String> lbls = new ArrayList<String>();
+		lbls.add("arrTaint");
+		arr = MultiTainter.taintedIntArray(arr, lbls);
+		//System.out.println("arr[0] taint: " + MultiTainter.getTaint(arr[0]));
+		assertEquals(lbls, MultiTainter.getTaint(arr[0]));
+		
+		ArrayList<String> intTaints = new ArrayList<String>();
+		intTaints.add("intTaint");
+		int i = MultiTainter.taintedInt(5, intTaints);
+		//System.out.println("i taint: " + MultiTainter.getTaint(i));
+		assertEquals(intTaints, MultiTainter.getTaint(i));
+		
+		arr[0] = i + 9;
+		//System.out.println("arr[0] taint again: " + MultiTainter.getTaint(arr[0]).getDependencies().toString());
+		assertEquals("[intTaint]", MultiTainter.getTaint(arr[0]).getDependencies().toString());
+	}
+	
+	public static void main(String[] args) {
+		testIncrementArray();
+	}
+
+}

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/IOTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/IOTagITCase.java
@@ -1,12 +1,16 @@
 package edu.columbia.cs.psl.test.phosphor;
 
 import java.util.ArrayList;
+
+import org.junit.Test;
+
 import static org.junit.Assert.*;
 
 import edu.columbia.cs.psl.phosphor.runtime.MultiTainter;
 
 public class IOTagITCase {
 	
+	@Test
 	public static void testIncrementArray() {
 		int[] arr = {1, 2, 3};
 		ArrayList<String> lbls = new ArrayList<String>();


### PR DESCRIPTION
Assume I have an int i tainted with the label "intLabel" and an array arr tainted with the label "arrLabel". If I do arr[0] = i + 9, the expected dependencies should be [i], but now the tait for arr[0] is like:
lbl: [i]
deps:[]