### PR TITLE
added test case for runtime annotation problem.

### DIFF
--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/RuntimeAnnotationExample.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/RuntimeAnnotationExample.java
@@ -1,0 +1,23 @@
+package edu.columbia.cs.psl.test.phosphor;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.LOCAL_VARIABLE;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PACKAGE;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.ElementType.TYPE_PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target({ TYPE, FIELD, METHOD, PARAMETER, CONSTRUCTOR, LOCAL_VARIABLE, ANNOTATION_TYPE, PACKAGE, TYPE_PARAMETER,
+		TYPE_USE })
+public @interface RuntimeAnnotationExample {
+	String[] value();
+}

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/RuntimeAnnotationImplicitITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/RuntimeAnnotationImplicitITCase.java
@@ -1,0 +1,22 @@
+package edu.columbia.cs.psl.test.phosphor;
+
+import org.junit.Test;
+
+public class RuntimeAnnotationImplicitITCase {
+
+	
+	@Test
+	public void testSimpleIf()  {
+		// this will crash if the test fails.
+		@RuntimeAnnotationExample("EXAMPLE") int a = 100;
+		
+		
+		a = a + 100;
+		
+		int b = 10;
+		
+		a = b + 1;
+		
+		
+	}
+}


### PR DESCRIPTION
This just *crashes* -- so I'm not sure how it gets picked up in the unit tests or what convention you are using for that since the other tests look like the assume a working Phosphor. 

If you let me know what you do in this case I'll add it. If you run with: 

```
mvn verify -P integration-test-implicit-tracking
```

You'll see the crash near the end. 