### PR TITLE
added test cases

### DIFF
--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/ArrayLengthObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/ArrayLengthObjTagITCase.java
@@ -114,12 +114,52 @@ public class ArrayLengthObjTagITCase {
 		else
 			assertNull(r);
 	}
-	
+
 	@Test
 	public void testArrayListGet() throws Exception {
 		ArrayList<String> al = new ArrayList<String>();
 		al.add("foo");
 		int i = MultiTainter.taintedInt(0, "foo");
 		System.out.println(MultiTainter.getTaint(al.get(i)));
+	}
+
+	// is it possible to taint an n dimensional array in the following ways
+	@Test
+	public void testArrayTaint() throws Exception{
+		int[][][] i  = {{{1,2,3}, {3,4,5}}, {{6,7,8}, {9,10,11}}};
+		//1
+		MultiTainter.taintedObject(i, new Taint("tainted"));
+
+		//2
+		for (int[][] idx : i)
+		{
+			MultiTainter.taintedObject(idx, new Taint("tainted"));
+		}
+
+		// 3
+		for (int[][] idx : i)
+		{
+			for (int[] idx1 : idx)
+			{
+				MultiTainter.taintedObject(idx1, new Taint("tainted"));
+				idx1 = MultiTainter.taintedIntArray(idx1, "tainted");
+			}
+		}
+
+		System.out.println(MultiTainter.getTaint(i));
+
+		System.out.println(MultiTainter.getTaint(i[0]));
+		System.out.println(MultiTainter.getTaint(i[1]));
+
+
+		System.out.println(MultiTainter.getTaint(i[0][0]));
+		System.out.println(MultiTainter.getTaint(i[0][1]));
+
+
+		System.out.println(MultiTainter.getTaint(i[0][0][0]));
+		System.out.println(MultiTainter.getTaint(i[0][0][1]));
+
+
+
 	}
 }

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/ReflectionObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/ReflectionObjTagITCase.java
@@ -13,7 +13,7 @@ import edu.columbia.cs.psl.phosphor.runtime.MultiTainter;
 import edu.columbia.cs.psl.phosphor.runtime.Taint;
 
 public class ReflectionObjTagITCase {
-	
+
 	static class FieldHolder{
 		int i;
 		long j;
@@ -23,7 +23,27 @@ public class ReflectionObjTagITCase {
 		byte b;
 		char c;
 	}
-	
+
+	static class ArrayFieldHolder{
+		int[] arr_i = {1,2,3,4,5};
+	}
+
+	@Test
+	public void testReflectSetFieldArray() throws Exception{
+		ArrayFieldHolder fh = new ArrayFieldHolder();
+		for (Field f : fh.getClass().getDeclaredFields())
+		{
+			int[] temp = (int[])f.get(fh);
+			temp = MultiTainter.taintedIntArray(temp, "tainted");
+		}
+		assertNotNull(MultiTainter.getTaint(fh.arr_i[0]));
+		assertNotNull(MultiTainter.getTaint(fh.arr_i[1]));
+		assertNotNull(MultiTainter.getTaint(fh.arr_i[2]));
+		assertNotNull(MultiTainter.getTaint(fh.arr_i[3]));
+		assertNotNull(MultiTainter.getTaint(fh.arr_i[4]));
+	}
+
+
 	@Test
 	public void testReflectionSetField() throws Exception {
 		FieldHolder fh = new FieldHolder();
@@ -92,7 +112,7 @@ public class ReflectionObjTagITCase {
 			Integer obj = list.get(i);
 			int objVal = list.get(i);
 
-			Taint objTaint = MultiTainter.getTaint(obj); 
+			Taint objTaint = MultiTainter.getTaint(obj);
 			Taint valTaint = MultiTainter.getTaint(objVal);
 			assertEquals(objTaint.lbl, valTaint.lbl);
 		}


### PR DESCRIPTION
I get the following error when I try to taint an instance variable of type int[] using reflection 

Exception in thread "main" java.lang.ClassCastException: java.lang.Long cannot be cast to edu.columbia.cs.psl.phosphor.struct.LazyIntArrayObjTags
	at java.lang.Throwable.fillInStackTrace$$PHOSPHORTAGGED(Throwable.java)
	at java.lang.Throwable.fillInStackTrace$$PHOSPHORTAGGED(Throwable.java:783)
	at java.lang.Throwable.<init>(Throwable.java:265)
	at java.lang.Exception.<init>(Exception.java:66)
	at java.lang.RuntimeException.<init>(RuntimeException.java:62)
	at java.lang.ClassCastException.<init>(ClassCastException.java:58)
	at java.lang.ClassCastException.<init>(ClassCastException.java)
	at rough_work.rough_work.main$$PHOSPHORTAGGED(rough_work.java:62)
	at rough_work.rough_work.main(rough_work.java)

My second doubt is regrading tainting array references, is it possible to taint array using MultiTainter.taintedObject() method. 

I have added two test cases for the above mentioned scenarios